### PR TITLE
Fix name validation in batch rename script

### DIFF
--- a/BatchRenameGameObjects.cs
+++ b/BatchRenameGameObjects.cs
@@ -111,7 +111,7 @@ public class BatchRenameGameObjects : EditorWindow
     {
         string name = t_name.Trim(); //去除头尾空白字符串
         int index = t_index;
-        if ((name + index) != string.Empty) //若名字不为空
+        if (!string.IsNullOrEmpty(name)) //若名字不为空
         {
             bool isAssetsObject = false; //flag, 是否是assets文件夹的资源
 


### PR DESCRIPTION
## Summary
- avoid concatenating number when checking for a valid name

## Testing
- `csc BatchRenameGameObjects.cs` *(fails: command not found)*
- `mcs BatchRenameGameObjects.cs` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e4a150a4832bbabbfd138f2fdc7f